### PR TITLE
Pass BINDGEN_TARGET env to instruct what target bindgen is built for.

### DIFF
--- a/libuci-sys/build.rs
+++ b/libuci-sys/build.rs
@@ -17,6 +17,10 @@ fn main() {
     }
 
     let mut builder = bindgen::Builder::default();
+    // if BINDGEN_TARGET is set it instructs the target bindgen is built for
+    if let Ok(bindgen_target) = env::var("BINDGEN_TARGET") {
+        builder = builder.clang_arg(format!("--target={}", bindgen_target));
+    }
 
     // if UCI_DIR is present, use it to look for the header file and precompiled libs
     if let Ok(uci_dir) = env::var("UCI_DIR") {

--- a/libuci-sys/src/lib.rs
+++ b/libuci-sys/src/lib.rs
@@ -15,6 +15,8 @@
 //! If building inside the OpenWRT SDK with OpenWRT's UCI package set the environment variable
 //! `UCI_DIR=$(STAGING_DIR)/usr` using the corresponding Makefile.
 //! rust-uci will automatically use the headers and libraries for the target system.
+//! When crosscompiling it may be useful to set BINDGEN_TARGET to instruct what
+//! target bindgen is built for.
 //!
 //! ## Vendored
 //!


### PR DESCRIPTION
I had issues cross-compiling your crate and by adding the ability to pass the target bindgen builts for I was able to compile everything successfully.