### PR TITLE
Bump bindgen dependency

### DIFF
--- a/libuci-sys/Cargo.toml
+++ b/libuci-sys/Cargo.toml
@@ -15,5 +15,5 @@ exclude = ["libubox/tests/*", "uci/tests/*"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-bindgen = "^0.58.1"
+bindgen = "^0.69.4"
 cmake = "^0.1.45"

--- a/libuci-sys/build.rs
+++ b/libuci-sys/build.rs
@@ -55,7 +55,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .allowlist_function("uci_.*")
         .allowlist_type("uci_.*")
         .allowlist_var("uci_.*")


### PR DESCRIPTION
Just a bindgen version update and a fix to one call that's been deprecated.

Recently did some OpenWrt building on Ubuntu 24.04 which failed due to a newer clang version being used. This update fixes it without any further issue.