### PR TITLE
Fixed binding generation failure on anonymous union

### DIFF
--- a/libuci-sys/Cargo.toml
+++ b/libuci-sys/Cargo.toml
@@ -15,5 +15,5 @@ exclude = ["libubox/tests/*", "uci/tests/*"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-bindgen = "^0.69.4"
+bindgen = "^0.72.0"
 cmake = "^0.1.45"


### PR DESCRIPTION
When building `rust-uci` we experienced a panic in buildscript for the low-level bindings. This seems to be a case on newer LLVM versions and it was fixed later.

Updating dependency for fix.
(https://github.com/rust-lang/rust-bindgen/issues/2488)